### PR TITLE
Clarify requirements for running scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ This repository contains the source code used to produce the results presented i
 
 <br/>
 
+## Requirements
+
+To construct and optimize the variational quantum circuits, these scripts and notebooks use the TensorFlow backend of [Strawberry Fields](https://github.com/XanaduAI/strawberryfields). In addition, matplotlib is required for generating output plots.
+
+**Due to subsequent interface upgrades, these scripts will work only with the following
+configuration**
+ 
+- Strawberry Fields version 0.10.0
+- TensorFlow version 1.3
+- Python version 3.5 or 3.6
+
 ## Contents
 
 <!-- <p align="center">
@@ -21,14 +32,6 @@ This repository contains the source code used to produce the results presented i
 * **Tetrominos learning**: The folder `tetrominos_learning` contains the Python script `tetrominos_learning.py`, which trains a continuous-variable (CV) quantum neural network. The task of the network is to encode 7 different 4X4 images, representing the (L,O,T,I,S,J,Z) [tetrominos](https://en.wikipedia.org/wiki/Tetromino), in the photon number distribution of two light modes. Once the training phase is completed, the script `plot_images.py` can be executed in order to generate a `.png` figure representing the final results.
 
 <img align='right' src="https://github.com/XanaduAI/quantum-neural-networks/blob/master/static/tetronimo_gif.gif">
-
-
-## Requirements
-
-To construct and optimize the variational quantum circuits, these scripts and notebooks use the TensorFlow backend of [Strawberry Fields](https://github.com/XanaduAI/strawberryfields). In addition, matplotlib is required for generating output plots.
-
-**Due to subsequent interface upgrades, these scripts will work only with Strawberry Fields version <= 0.10.0.**
-
 
 ## Using the scripts
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ configuration**
 - TensorFlow version 1.3
 - Python version 3.5 or 3.6
 
+Your version of Python can be checked by running `python --version`. The correct versions of
+StrawberryFields and TensorFlow can be installed by running `pip install -r requirements.txt`
+from the main directory of this repository. 
+
 ## Contents
 
 <!-- <p align="center">

--- a/fraud_detection/fraud_detection.py
+++ b/fraud_detection/fraud_detection.py
@@ -20,6 +20,10 @@ import tensorflow as tf
 import strawberryfields as sf
 from strawberryfields.ops import Dgate, BSgate, Kgate, Sgate, Rgate
 
+import sys
+sys.path.append("..")
+import version_check
+
 # ===================================================================================
 #                                   Hyperparameters
 # ===================================================================================
@@ -190,21 +194,18 @@ def qnn_layer(layer_number):
 #                                   Defining QNN
 # ===================================================================================
 
-# construct the two-mode Strawberry Fields program
-prog = sf.Program(mode_number)
+# construct the two-mode Strawberry Fields engine
+eng, q = sf.Engine(mode_number)
 
 # construct the circuit
-with prog.context as q:
+with eng:
     input_qnn_layer()
 
     for i in range(depth):
         qnn_layer(i)
 
-# create an engine
-eng = sf.Engine('tf', backend_options={"cutoff_dim": cutoff, "batch_size": batch_size})
-
 # run the engine (in batch mode)
-state = eng.run(prog, run_options={"eval": False}).state
+state = eng.run("tf", cutoff_dim=cutoff, eval=False, batch_size=batch_size)
 # extract the state
 ket = state.ket()
 

--- a/fraud_detection/testing.py
+++ b/fraud_detection/testing.py
@@ -20,6 +20,10 @@ import tensorflow as tf
 import strawberryfields as sf
 from strawberryfields.ops import Dgate, BSgate, Kgate, Sgate, Rgate
 
+import sys
+sys.path.append("..")
+import version_check
+
 # ===================================================================================
 #                                   Hyperparameters
 # ===================================================================================
@@ -180,21 +184,18 @@ def qnn_layer(layer_number):
 #                                   Defining QNN
 # ===================================================================================
 
-# construct the two-mode Strawberry Fields program
-prog = sf.Program(mode_number)
+# construct the two-mode Strawberry Fields engine
+eng, q = sf.Engine(mode_number)
 
 # construct the circuit
-with prog.context as q:
+with eng:
     input_qnn_layer()
 
     for i in range(depth):
         qnn_layer(i)
 
-# create an engine
-eng = sf.Engine('tf', backend_options={"cutoff_dim": cutoff, "batch_size": batch_size})
-
 # run the engine (in batch mode)
-state = eng.run(prog, run_options={"eval": False}).state
+state = eng.run("tf", cutoff_dim=cutoff, eval=False, batch_size=batch_size)
 # extract the state
 ket = state.ket()
 

--- a/function_fitting/function_fitting.py
+++ b/function_fitting/function_fitting.py
@@ -25,6 +25,9 @@ import tensorflow as tf
 import strawberryfields as sf
 from strawberryfields.ops import *
 
+import sys
+sys.path.append("..")
+import version_check
 
 # ===================================================================================
 #                                   Hyperparameters

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+strawberryfields==0.10
+tensorflow==1.3
+matplotlib

--- a/tetrominos_learning/tetrominos_learning.py
+++ b/tetrominos_learning/tetrominos_learning.py
@@ -21,26 +21,8 @@ import time
 import os
 
 import sys
-python_version = sys.version_info
-sf_version = sf.__version__
-tf_version = tf.__version__.split(".")
-
-if python_version > (3, 6):
-    raise SystemError("")
-
-if python_version < (3, 5):
-    raise SystemError("Your version of python is {}.{}. You must have Python 3.5 or 3.6 installed "
-                      "to run this script.".format(python_version.major, python_version.minor))
-
-if sf_version != "0.10.0":
-    raise ImportError("An incorrect version of StrawberryFields is installed. You must have "
-                      "StrawberryFields version 0.10 to run this script. To install the correct "
-                      "version, run:\n >>> pip install strawberryfields==0.10")
-
-if not(tf_version[0] == "1" and tf_version[1] == "3"):
-    raise ImportError("An incorrect version of TensorFlow is installed. You must have "
-                      "TensorFlow version 1.3 to run this script. To install the correct "
-                      "version, run:\n >>> pip install tensorflow==1.3")
+sys.path.append("..")
+import version_check
 
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 os.environ['OMP_NUM_THREADS'] = '1'

--- a/tetrominos_learning/tetrominos_learning.py
+++ b/tetrominos_learning/tetrominos_learning.py
@@ -17,9 +17,30 @@ import strawberryfields as sf
 from strawberryfields.ops import Dgate, BSgate, Kgate, Sgate, Rgate
 import tensorflow as tf
 import numpy as np
-import matplotlib.pyplot as plt
 import time
 import os
+
+import sys
+python_version = sys.version_info
+sf_version = sf.__version__
+tf_version = tf.__version__.split(".")
+
+if python_version > (3, 6):
+    raise SystemError("")
+
+if python_version < (3, 5):
+    raise SystemError("Your version of python is {}.{}. You must have Python 3.5 or 3.6 installed "
+                      "to run this script.".format(python_version.major, python_version.minor))
+
+if sf_version != "0.10.0":
+    raise ImportError("An incorrect version of StrawberryFields is installed. You must have "
+                      "StrawberryFields version 0.10 to run this script. To install the correct "
+                      "version, run:\n >>> pip install strawberryfields==0.10")
+
+if not(tf_version[0] == "1" and tf_version[1] == "3"):
+    raise ImportError("An incorrect version of TensorFlow is installed. You must have "
+                      "TensorFlow version 1.3 to run this script. To install the correct "
+                      "version, run:\n >>> pip install tensorflow==1.3")
 
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 os.environ['OMP_NUM_THREADS'] = '1'

--- a/version_check.py
+++ b/version_check.py
@@ -1,0 +1,28 @@
+"""Script for checking the correct versions of Python, StrawberryFields and TensorFlow are being
+used."""
+import sys
+
+import strawberryfields as sf
+import tensorflow as tf
+
+python_version = sys.version_info
+sf_version = sf.__version__
+tf_version = tf.__version__.split(".")
+
+if python_version > (3, 6):
+    raise SystemError("Your version of python is {}.{}. You must have Python 3.5 or 3.6 installed "
+                      "to run this script.".format(python_version.major, python_version.minor))
+
+if python_version < (3, 5):
+    raise SystemError("Your version of python is {}.{}. You must have Python 3.5 or 3.6 installed "
+                      "to run this script.".format(python_version.major, python_version.minor))
+
+if sf_version != "0.10.0":
+    raise ImportError("An incorrect version of StrawberryFields is installed. You must have "
+                      "StrawberryFields version 0.10 to run this script. To install the correct "
+                      "version, run:\n >>> pip install strawberryfields==0.10")
+
+if not(tf_version[0] == "1" and tf_version[1] == "3"):
+    raise ImportError("An incorrect version of TensorFlow is installed. You must have "
+                      "TensorFlow version 1.3 to run this script. To install the correct "
+                      "version, run:\n >>> pip install tensorflow==1.3")

--- a/version_check.py
+++ b/version_check.py
@@ -18,11 +18,11 @@ if python_version < (3, 5):
                       "to run this script.".format(python_version.major, python_version.minor))
 
 if sf_version != "0.10.0":
-    raise ImportError("An incorrect version of StrawberryFields is installed. You must have "
+    raise ImportError("An incompatible version of StrawberryFields is installed. You must have "
                       "StrawberryFields version 0.10 to run this script. To install the correct "
                       "version, run:\n >>> pip install strawberryfields==0.10")
 
 if not(tf_version[0] == "1" and tf_version[1] == "3"):
-    raise ImportError("An incorrect version of TensorFlow is installed. You must have "
+    raise ImportError("An incompatible version of TensorFlow is installed. You must have "
                       "TensorFlow version 1.3 to run this script. To install the correct "
                       "version, run:\n >>> pip install tensorflow==1.3")

--- a/version_check.py
+++ b/version_check.py
@@ -9,11 +9,7 @@ python_version = sys.version_info
 sf_version = sf.__version__
 tf_version = tf.__version__.split(".")
 
-if python_version > (3, 6):
-    raise SystemError("Your version of python is {}.{}. You must have Python 3.5 or 3.6 installed "
-                      "to run this script.".format(python_version.major, python_version.minor))
-
-if python_version < (3, 5):
+if python_version < (3, 5) or python_version > (3, 6):
     raise SystemError("Your version of python is {}.{}. You must have Python 3.5 or 3.6 installed "
                       "to run this script.".format(python_version.major, python_version.minor))
 


### PR DESCRIPTION
This PR does the following:

- Takes requirements closer to the top in the README
- Ensures that all scripts work for Strawberry Fields version 0.10, requiring the fraud detection scripts to be changed from the v0.11+ interface to v0.10
- Adds a script that raises exceptions if the strict requirements are not met. This might seem overkill, but appears the best way for now to ensure users are working with the right configuration.
- Makes the above script run for all the experiments.

We have nearly merged in support for TF2 in SF: https://github.com/XanaduAI/strawberryfields/pull/323
Once done and a new version of SF is released, it would be ideal to carefully go through these scripts and update to the new TF2 backend.

Closes https://github.com/XanaduAI/quantum-neural-networks/issues/9.